### PR TITLE
Add interval manifest

### DIFF
--- a/i.go
+++ b/i.go
@@ -1,0 +1,78 @@
+package r
+
+import (
+	"errors"
+	"time"
+)
+
+// Trying to stop an interval that hasn't already
+// been running returns this error.
+var stopErr = errors.New("i: interval not running")
+
+// I is a manifest for a function/method that should
+// be run at the given interval. The next call is
+// schedule right at the beginning of the current call
+// so that the pulse isn't affected by how long the
+// function takes to run.
+type I struct {
+	fn      func()
+	intv    time.Duration
+	timer   chan struct{}
+	running bool
+}
+
+func NewInterval(intv time.Duration, f func()) *I {
+	return &I{
+		fn:      f,
+		intv:    intv,
+		timer:   make(chan struct{}, 1),
+		running: false,
+	}
+}
+
+// Starts the intervaled execution of the function.
+// It returns the internal timer channel. Closing
+// the channel stops the execution.
+func (i *I) Start() bool {
+	if i.running {
+		return false
+	}
+
+	i.running = true
+	// Start a goroutine to control pulse of execution.
+	go func() {
+		for i.running {
+			i.timer <- struct{}{}
+			time.Sleep(i.intv)
+		}
+		close(i.timer)
+	}()
+
+	go func() {
+		for {
+			// We continue to start new goroutines to run the function
+			// until the interval is stopped (aka timer channel is closed)
+			// in which case we'd receive a non-OK default value.
+			_, ok := <-i.timer
+			if !ok {
+				break
+			}
+
+			go i.fn()
+		}
+	}()
+
+	return true
+}
+
+// Stop stops a running interval.
+// If the interval was already stopped or not running,
+// an error is returned.
+func (i *I) Stop() error {
+	if !i.running {
+		return stopErr
+	}
+
+	i.running = false
+	return nil
+}

--- a/i_test.go
+++ b/i_test.go
@@ -1,0 +1,75 @@
+package r
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	i := NewInterval(time.Second, func() {})
+	if cap(i.timer) != 1 {
+		t.Fatalf("expected channel buffer size 1; got=%d instead", cap(i.timer))
+	}
+
+	if i.running {
+		t.Fatalf("expected running to be false")
+	}
+}
+
+func wait(secs int) {
+	asDur := time.Duration(secs)
+	time.Sleep(asDur * time.Second)
+}
+
+// TODO(yawboakye): Revisit this test case. I'm not
+// confident that I've tested it the best way possible.
+func TestStart(t *testing.T) {
+	var calls int
+	var expected = 1 + rand.Intn(5)
+
+	i := NewInterval(time.Second, func() { calls++ })
+
+	// Start the interval, wait for the expected number of
+	// calls and then stop it.
+	i.Start()
+	wait(expected)
+	i.running = false // instead of `i.Stop()`
+
+	// expect the function to be have been called
+	// the expected number of times.
+	if calls != expected {
+		t.Fatalf("expected=%d; got=%d instead", expected, calls)
+	}
+}
+
+func TestStartStart(t *testing.T) {
+	i := NewInterval(time.Second, func() {})
+	i.Start()
+	if ok := i.Start(); ok {
+		t.Fatalf("started an already running interval")
+	}
+	i.Stop()
+}
+
+func TestStop(t *testing.T) {
+	i := NewInterval(time.Second, func() {})
+	i.Start()
+	wait(1)
+	i.Stop()
+
+	// expect `running` to be false
+	if i.running {
+		t.Fatalf("interval still running. not stopped")
+	}
+
+	// expect the timer channel to be closed
+	if _, ok := <-i.timer; ok {
+		t.Fatalf("expected timer channel to be closed")
+	}
+
+	// stopping an already stopped interval returns error
+	if err := i.Stop(); err == nil {
+		t.Fatalf("expected=%v; got=%v instead", stopErr, nil)
+	}
+}


### PR DESCRIPTION
execute function at set interval, independent of how long the function
takes to run. that is if the manifest specifies a 1-second interval but
the function takes 5-second to run, 4 other calls will be running (as
goroutines) by the time the first call ends.